### PR TITLE
fix: adding a redirect for www.{default} to {default}

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,3 +1,13 @@
-https://{default}/:
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going to be processed by Platform.sh.
+#
+# See https://docs.platform.sh/user_guide/reference/routes-yaml.html
+
+"https://{default}/":
   type: upstream
   upstream: "app:http"
+
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"


### PR DESCRIPTION
## Description
Adding a redirect for  www.{default} to {default}

## Motivation and Context
There was no routing defined for  `www.{default}` and hence, if someone tried to access the www domain it would throw an error. To fix this, I've added a redirect. 

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
